### PR TITLE
Fixes deprecated ${var} usage in PHP 8.2

### DIFF
--- a/src/FormRequestTester.php
+++ b/src/FormRequestTester.php
@@ -451,7 +451,7 @@ class FormRequestTester
             $this->test->assertContains(
                 $message,
                 $errors,
-                "Failed to find the validation message '${message}' in the validation messages"
+                "Failed to find the validation message '{$message}' in the validation messages"
             );
         }
 


### PR DESCRIPTION
See: 
https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated